### PR TITLE
bot-statusとメンテナンスに関するアプデ

### DIFF
--- a/botmain.js
+++ b/botmain.js
@@ -60,7 +60,10 @@ client.once("ready", async() => {
         await statusAndMode.status(2,"BOTメンテナンス");
     }
     else{
-        await mode.status(0,"BOT起動完了");
+        const date = new Date();
+        let status=0;
+        if(date.getHours()*100+date.getMinutes()>=204 && date.getHours()*100+date.getMinutes()<=509)status=1;
+        await mode.status(status,"BOT起動完了");
     }
 });
 
@@ -202,7 +205,33 @@ client.on('messageCreate', message => {
 
 /*ステータス更新*/
 cron.schedule('* * * * *', async () => {
-    await mode.status(0,"毎分実行の勝利");
+    if(JSON.parse(fs.readFileSync(configPath, 'utf8')).maintenanceMode === false) {
+        const date = new Date();
+        let status=0;
+        if(date.getHours()*100+date.getMinutes()>=204 && date.getHours()*100+date.getMinutes()<=509)status=1;
+        const time = Math.floor(date.getTime() / 1000 / 60)%6
+        switch(time){
+            case 0:
+                await mode.status(status,`$導入数：{client.guilds.cache.size}サーバー`);
+                break;
+            case 1:
+                await mode.status(status,`ヘルプ：/help`);
+                break;
+            case 2:
+                await mode.status(status,`時間割：/timetable`);
+                break;
+            case 3:
+                await mode.status(status,`天気：/weather`);
+                break;
+            case 4:
+                await mode.status(status,`匿名投稿：/secret-msg`);
+                break;
+            case 5:
+                await mode.status(status,`チャンネル作成：/create-channel`);
+                break;
+        }
+    }
+
 });
 
 /*誕生日通知とGuildDataチェック、時間割変更データチェック*/
@@ -271,7 +300,7 @@ cron.schedule('0 20 * * 0,1,2,3,4', async () => {
 });
 
 /*天気*/
-cron.schedule('15 17 * * *', async() => {
+cron.schedule('0 20 * * *', async() => {
     const embed = await weather.generationDay(1);
     const data = await db.find("main", "guildData", {main: {$nin: [ID_NODATA]}});
     for(let i = 0; i < data.length; i++) {

--- a/botmain.js
+++ b/botmain.js
@@ -36,6 +36,7 @@ const weather = require('./functions/weather.js');
 const guildData = require("./functions/guildDataSet.js");
 const {ID_NODATA} = require("./functions/guildDataSet.js");
 const CreateChannel = require("./functions/CCFunc.js");
+const mode = require("./functions/status&mode.js");
 
 //スラッシュコマンド登録
 const commandsPath = path.join(__dirname, 'commands');
@@ -43,6 +44,7 @@ const commandFiles = fs.readdirSync(commandsPath).filter(file => file.endsWith('
 client.commands = new Collection();
 module.exports = client.commands;
 client.once("ready", async() => {
+    await mode.status(2,"BOT起動処理");
     for(const file of commandFiles) {
         const filePath = path.join(commandsPath, file);
         const command = require(filePath);
@@ -53,6 +55,7 @@ client.once("ready", async() => {
     await weather.update(); //天気更新
     await CreateChannel.dataCheck();
     await system.log("Ready!");
+    await mode.status(0,"BOT起動完了");
 });
 
 /*command処理*/
@@ -191,9 +194,10 @@ client.on('messageCreate', message => {
     }
 });
 
-/*誕生日通知とGuildDataチェック、時間割変更データチェック*/
-cron.schedule('0 0 * * *', async () => {
-    await birthday.func();
+
+
+/*メンテナンスモード*/
+cron.schedule('59 4 * * *', async () => {
     await guildData.checkGuild();
     await timetable.deleteData();
 });

--- a/botmain.js
+++ b/botmain.js
@@ -37,7 +37,7 @@ const guildData = require("./functions/guildDataSet.js");
 const {ID_NODATA} = require("./functions/guildDataSet.js");
 const CreateChannel = require("./functions/CCFunc.js");
 const mode = require("./functions/status&mode.js");
-const statusAndMode = require("./functions/status&mode");
+const statusAndMode = require("./functions/status&mode.js");
 
 //スラッシュコマンド登録
 const commandsPath = path.join(__dirname, 'commands');
@@ -204,13 +204,8 @@ client.on('messageCreate', message => {
 cron.schedule('* * * * *', async () => {
     if(JSON.parse(fs.readFileSync(configPath, 'utf8')).maintenanceMode === false) {
         const date = new Date();
-        let status=0;
-        if(date.getHours()*100+date.getMinutes()>=204 && date.getHours()*100+date.getMinutes()<=509)status=1;
         const time = Math.floor(date.getTime() / 1000 / 60)%6
         switch(time){
-            case 0:
-                await mode.status(0,`導入数：${client.guilds.cache.size}サーバー`);
-                break;
             case 1:
                 await mode.status(0,`ヘルプ：/help`);
                 break;
@@ -226,6 +221,8 @@ cron.schedule('* * * * *', async () => {
             case 5:
                 await mode.status(0,`チャンネル作成：/create-channel`);
                 break;
+            default:
+                await mode.status(0,`導入数：${client.guilds.cache.size}サーバー`);
         }
     }
 

--- a/botmain.js
+++ b/botmain.js
@@ -37,6 +37,7 @@ const guildData = require("./functions/guildDataSet.js");
 const {ID_NODATA} = require("./functions/guildDataSet.js");
 const CreateChannel = require("./functions/CCFunc.js");
 const mode = require("./functions/status&mode.js");
+const statusAndMode = require("./functions/status&mode");
 
 //スラッシュコマンド登録
 const commandsPath = path.join(__dirname, 'commands');
@@ -55,7 +56,12 @@ client.once("ready", async() => {
     await weather.update(); //天気更新
     await CreateChannel.dataCheck();
     await system.log("Ready!");
-    await mode.status(0,"BOT起動完了");
+    if(config.maintenanceMode === true){
+        await statusAndMode.status(2,"BOTメンテナンス");
+    }
+    else{
+        await mode.status(0,"BOT起動完了");
+    }
 });
 
 /*command処理*/

--- a/botmain.js
+++ b/botmain.js
@@ -194,12 +194,23 @@ client.on('messageCreate', message => {
     }
 });
 
+/*ステータス更新*/
+cron.schedule('* * * * *', async () => {
+    await mode.status(0,"毎分実行の勝利");
+});
 
+/*誕生日通知とGuildDataチェック、時間割変更データチェック*/
+cron.schedule('0 0 * * *', async () => {
+    await birthday.func();
+
+});
 
 /*メンテナンスモード*/
 cron.schedule('59 4 * * *', async () => {
+    await mode.maintenance(true);
     await guildData.checkGuild();
     await timetable.deleteData();
+    await mode.maintenance(false);
 });
 
 /*原神デイリー通知*/

--- a/botmain.js
+++ b/botmain.js
@@ -60,10 +60,7 @@ client.once("ready", async() => {
         await statusAndMode.status(2,"BOTメンテナンス");
     }
     else{
-        const date = new Date();
-        let status=0;
-        if(date.getHours()*100+date.getMinutes()>=204 && date.getHours()*100+date.getMinutes()<=509)status=1;
-        await mode.status(status,"BOT起動完了");
+        await mode.status(0,"BOT起動完了");
     }
 });
 
@@ -212,22 +209,22 @@ cron.schedule('* * * * *', async () => {
         const time = Math.floor(date.getTime() / 1000 / 60)%6
         switch(time){
             case 0:
-                await mode.status(status,`$導入数：{client.guilds.cache.size}サーバー`);
+                await mode.status(0,`導入数：${client.guilds.cache.size}サーバー`);
                 break;
             case 1:
-                await mode.status(status,`ヘルプ：/help`);
+                await mode.status(0,`ヘルプ：/help`);
                 break;
             case 2:
-                await mode.status(status,`時間割：/timetable`);
+                await mode.status(0,`時間割：/timetable`);
                 break;
             case 3:
-                await mode.status(status,`天気：/weather`);
+                await mode.status(0,`天気：/weather`);
                 break;
             case 4:
-                await mode.status(status,`匿名投稿：/secret-msg`);
+                await mode.status(0,`匿名投稿：/secret-msg`);
                 break;
             case 5:
-                await mode.status(status,`チャンネル作成：/create-channel`);
+                await mode.status(0,`チャンネル作成：/create-channel`);
                 break;
         }
     }

--- a/botmain.js
+++ b/botmain.js
@@ -36,8 +36,8 @@ const weather = require('./functions/weather.js');
 const guildData = require("./functions/guildDataSet.js");
 const {ID_NODATA} = require("./functions/guildDataSet.js");
 const CreateChannel = require("./functions/CCFunc.js");
-const mode = require("./functions/status&mode.js");
-const statusAndMode = require("./functions/status&mode.js");
+const mode = require("./functions/statusAndMode.js");
+const statusAndMode = require("./functions/statusAndMode.js");
 
 //スラッシュコマンド登録
 const commandsPath = path.join(__dirname, 'commands');

--- a/commands/dashboard.js
+++ b/commands/dashboard.js
@@ -106,9 +106,10 @@ module.exports =
                     const reply = await interaction.editReply("このサーバーには既に自動更新のダッシュボードが存在します。\n新たに生成するボードに自動更新を変更する場合は:o:を、操作をキャンセルする場合は:x:を1分以内にリアクションしてください。");
                     await reply.react('⭕');
                     await reply.react('❌');
-                    const sleep = waitTime => new Promise( resolve => setTimeout(resolve, waitTime) );
-                    sleep(100);
-                    let flag = -1,otherReact =[0,0];
+
+                    let flag = -1
+                    const otherReact =[0,0];
+                    await setTimeout(100);
 
                     while(flag === -1){
                         await reply.awaitReactions({ filter: reaction => reaction.emoji.name === '⭕' || reaction.emoji.name === '❌', max: 1 , time: 60_000})

--- a/commands/dashboard.js
+++ b/commands/dashboard.js
@@ -106,6 +106,8 @@ module.exports =
                     const reply = await interaction.editReply("このサーバーには既に自動更新のダッシュボードが存在します。\n新たに生成するボードに自動更新を変更する場合は:o:を、操作をキャンセルする場合は:x:を1分以内にリアクションしてください。");
                     await reply.react('⭕');
                     await reply.react('❌');
+                    const sleep = waitTime => new Promise( resolve => setTimeout(resolve, waitTime) );
+                    sleep(100);
                     let flag = -1,otherReact =[0,0];
 
                     while(flag === -1){

--- a/commands/general.js
+++ b/commands/general.js
@@ -111,9 +111,9 @@ module.exports =
                     const reply = await interaction.editReply("あなたはシステム管理者から通常の講習を受けたはずです。\nこれは通常、以下の3点に要約されます:\n    #1) 他人のプライバシーを尊重すること。\n    #2) タイプする前に考えること。\n    #3) 大いなる力には大いなる責任が伴うこと。");
                     await reply.react('⭕');
                     await reply.react('❌');
+
                     flag = 0;
-                    const sleep = waitTime => new Promise( resolve => setTimeout(resolve, waitTime) );
-                    sleep(100);
+                    await setTimeout(100);
 
                     await reply.awaitReactions({ filter: reaction => reaction.emoji.name === '⭕' || reaction.emoji.name === '❌', max: 1 })
                         .then(() => {
@@ -124,7 +124,7 @@ module.exports =
                     await reply.reactions.removeAll();
                     if(flag === 1){
                         await mode.maintenance(interaction.options.getBoolean('option'));
-                        await interaction.editReply( `メンテナンスモードを${interaction.options.getBoolean('option')}にしました。` );
+                        await interaction.editReply( `メンテナンスモードを${interaction.options.getBoolean('option')}にしました` );
                     }
                     else{
                         await interaction.editReply( `変更を取りやめました` );

--- a/commands/general.js
+++ b/commands/general.js
@@ -7,7 +7,7 @@ const weather = require('../functions/weather.js');
 const db = require('../functions/db.js');
 const fs = require("fs");
 const {configPath} = require("../environmentConfig.js");
-const mode = require("../functions/status&mode.js");
+const mode = require("../functions/statusAndMode.js");
 
 
 module.exports =

--- a/commands/general.js
+++ b/commands/general.js
@@ -6,7 +6,8 @@ const system = require('../functions/logsystem.js');
 const weather = require('../functions/weather.js');
 const db = require('../functions/db.js');
 const fs = require("fs");
-const {configPath} = require("../environmentConfig");
+const {configPath} = require("../environmentConfig.js");
+const mode = require("../functions/status&mode.js");
 
 
 module.exports =
@@ -113,17 +114,15 @@ module.exports =
                     flag = 0;
 
                     await reply.awaitReactions({ filter: reaction => reaction.emoji.name === '⭕' || reaction.emoji.name === '❌', max: 1 })
-                        .then(collected => {
+                        .then(() => {
                             if(reply.reactions.cache.at(0).count === 2){
                                 flag = 1;
                             }
                         })
                     await reply.reactions.removeAll();
                     if(flag === 1){
-                        config.maintenanceMode = interaction.options.getBoolean('option');
-                        fs.writeFileSync(configPath, JSON.stringify(config,null ,"\t"));
-                        await system.warn(`メンテナンスモードを${config.maintenanceMode}にしました。`,"メンテナンスモード変更");
-                        await interaction.editReply( `メンテナンスモードを${config.maintenanceMode}にしました。` );
+                        await mode.maintenance(interaction.options.getBoolean('option'));
+                        await interaction.editReply( `メンテナンスモードを${interaction.options.getBoolean('option')}にしました。` );
                     }
                     else{
                         await interaction.editReply( `変更を取りやめました` );

--- a/commands/general.js
+++ b/commands/general.js
@@ -112,6 +112,8 @@ module.exports =
                     await reply.react('⭕');
                     await reply.react('❌');
                     flag = 0;
+                    const sleep = waitTime => new Promise( resolve => setTimeout(resolve, waitTime) );
+                    sleep(100);
 
                     await reply.awaitReactions({ filter: reaction => reaction.emoji.name === '⭕' || reaction.emoji.name === '❌', max: 1 })
                         .then(() => {

--- a/functions/status&mode.js
+++ b/functions/status&mode.js
@@ -18,6 +18,10 @@ exports.status = async function func(status,presence="") {
             name: presence
         }],
     });
+    if(status === 0){
+        const date = new Date();
+        if(date.getHours()*100+date.getMinutes()>=204 && date.getHours()*100+date.getMinutes()<=509)status=1;
+    }
     client.user.setStatus(statusName[status]);
 }
 

--- a/functions/status&mode.js
+++ b/functions/status&mode.js
@@ -1,5 +1,8 @@
-const {EmbedBuilder} = require("discord.js");
-const config = require("../environmentConfig");
+
+const fs = require("fs");
+const {configPath} = require("../environmentConfig");
+const system = require("./logsystem");
+const statusAndMode = require("./status&mode");
 
 const statusName = ['online','idle','dnd','invisible'];
 
@@ -19,6 +22,11 @@ exports.status = async function func(status,presence="") {
 }
 
 exports.maintenance = async function (mode){
+    const config = JSON.parse(fs.readFileSync(configPath, 'utf8'));
+    config.maintenanceMode = mode;
+    fs.writeFileSync(configPath, JSON.stringify(config,null ,"\t"));
+    await system.warn(`メンテナンスモードを${config.maintenanceMode}にしました。`,"メンテナンスモード変更");
+
     if(mode){
         await statusAndMode.status(2,"BOTメンテナンス");
     }

--- a/functions/status&mode.js
+++ b/functions/status&mode.js
@@ -2,7 +2,7 @@
 const fs = require("fs");
 const {configPath} = require("../environmentConfig");
 const system = require("./logsystem");
-const statusAndMode = require("./status&mode");
+const statusAndMode = require("./status&mode.js");
 
 const statusName = ['online','idle','dnd','invisible'];
 
@@ -19,12 +19,18 @@ exports.status = async function func(status,presence="") {
         }],
     });
     if(status === 0){
+        let statusData = status;
         const date = new Date();
-        if(date.getHours()*100+date.getMinutes()>=204 && date.getHours()*100+date.getMinutes()<=509)status=1;
+        if(date.getHours()*100+date.getMinutes()>=204 && date.getHours()*100+date.getMinutes()<=509)statusData=1;
     }
-    client.user.setStatus(statusName[status]);
+    client.user.setStatus(statusName[statusData]);
 }
 
+/***
+ * メンテナンスモードを切り替えます
+ * @param mode Trueでメンテナンスモード
+ * @returns {Promise<void>}
+ */
 exports.maintenance = async function (mode){
     const config = JSON.parse(fs.readFileSync(configPath, 'utf8'));
     config.maintenanceMode = mode;

--- a/functions/status&mode.js
+++ b/functions/status&mode.js
@@ -31,6 +31,9 @@ exports.maintenance = async function (mode){
         await statusAndMode.status(2,"BOTメンテナンス");
     }
     else{
-        await statusAndMode.status(0,"メンテナンス完了");
+        const date = new Date();
+        let status=0;
+        if(date.getHours()*100+date.getMinutes()>=204 && date.getHours()*100+date.getMinutes()<=509)status=1;
+        await statusAndMode.status(status,"メンテナンス完了");
     }
 }

--- a/functions/status&mode.js
+++ b/functions/status&mode.js
@@ -1,0 +1,28 @@
+const {EmbedBuilder} = require("discord.js");
+const config = require("../environmentConfig");
+
+const statusName = ['online','idle','dnd','invisible'];
+
+/***
+ * botのステータスを設定
+ * @param status　[オンライン,退席中,取り込み中,オフライン]の位置で指定
+ * @param presence ○○をプレイ中 のメッセージ
+ * @returns {Promise<void>}
+ */
+exports.status = async function func(status,presence="") {
+    client.user.setPresence({
+        activities: [{
+            name: presence
+        }],
+    });
+    client.user.setStatus(statusName[status]);
+}
+
+exports.maintenance = async function (mode){
+    if(mode){
+        await statusAndMode.status(2,"BOTメンテナンス");
+    }
+    else{
+        await statusAndMode.status(0,"メンテナンス完了");
+    }
+}

--- a/functions/statusAndMode.js
+++ b/functions/statusAndMode.js
@@ -2,7 +2,7 @@
 const fs = require("fs");
 const {configPath} = require("../environmentConfig");
 const system = require("./logsystem");
-const statusAndMode = require("./status&mode.js");
+const statusAndMode = require("./statusAndMode.js");
 
 const statusName = ['online','idle','dnd','invisible'];
 

--- a/functions/statusAndMode.js
+++ b/functions/statusAndMode.js
@@ -1,7 +1,6 @@
-
 const fs = require("fs");
-const {configPath} = require("../environmentConfig");
-const system = require("./logsystem");
+const {configPath} = require("../environmentConfig.js");
+const system = require("./logsystem.js");
 const statusAndMode = require("./statusAndMode.js");
 
 const statusName = ['online','idle','dnd','invisible'];

--- a/package.json
+++ b/package.json
@@ -23,14 +23,14 @@
   },
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/NITKC22s/bot-main.git"
+    "url": "git+https://github.com/NITKC-DEV/Kisarazu-Multi-Manager.git"
   },
   "author": "",
   "license": "ISC",
   "bugs": {
-    "url": "https://github.com/NITKC22s/bot-main/issues"
+    "url": "https://github.com/NITKC-DEV/Kisarazu-Multi-Manager/issues"
   },
-  "homepage": "https://github.com/NITKC22s/bot-main#readme",
+  "homepage": "https://github.com/NITKC-DEV/Kisarazu-Multi-Manager#readme",
   "devDependencies": {
     "cross-env": "^7.0.3"
   }


### PR DESCRIPTION
# 新機能及び機能の更新
 - status関数を作成(ステータスを切り替えられる関数)
 - メンテナンスモードの切り替えをmaintenance関数に移行
 - メンテナンスモード中はBOTのステータスが取り込み中になるように
 - 寮の消灯時間のときはBOTも退席中になるように
 - BOT起動時にBOTのステータスを更新するように
 - 1分毎にBOTのカスタムステータスを更新するように
 - 4時59分からメンテナンスモードを実施するように

# その他修正
 - 天気自動送信の時刻が間違ってた問題を修正
 - リアクションで応答するタイプのやつの確実性を高めるために0.1sの遅延を追加